### PR TITLE
Always return resolution as integer

### DIFF
--- a/bmlab/file.py
+++ b/bmlab/file.py
@@ -153,8 +153,8 @@ class Payload(object):
 
         """
         self.repetition = repetition
-        self.resolution = tuple(payload_group.attrs.get(
-            'resolution-%s' % axis)[0] for axis in ['x', 'y', 'z'])
+        self.resolution = tuple(int(payload_group.attrs.get(
+            'resolution-%s' % axis)[0]) for axis in ['x', 'y', 'z'])
         self.data = payload_group.get('data')
 
     def image_keys(self):


### PR DESCRIPTION
For older measurements this was stored as float64