### PR TITLE
Move extraction to cal controller, also save payload spectra

### DIFF
--- a/bmlab/models/calibration_model.py
+++ b/bmlab/models/calibration_model.py
@@ -13,6 +13,7 @@ class CalibrationModel(Serializer):
 
     def __init__(self):
         self.calib_times = {}
+        self.spectra = {}
         self.brillouin_regions = {}
         self.rayleigh_regions = {}
         self.brillouin_fits = BrillouinFitSet()
@@ -96,6 +97,15 @@ class CalibrationModel(Serializer):
 
     def clear_rayleigh_fits(self, calib_key):
         self.rayleigh_fits.clear(calib_key)
+
+    def set_spectra(self, calib_key, spectra):
+        self.spectra[calib_key] = spectra
+
+    def get_spectra(self, calib_key):
+        spectra = self.spectra.get(calib_key)
+        if spectra:
+            return spectra
+        return None
 
     def get_sorted_peaks(self, calib_key, frame_num):
         """

--- a/bmlab/models/evaluation_model.py
+++ b/bmlab/models/evaluation_model.py
@@ -11,6 +11,7 @@ class EvaluationModel(Serializer):
     def __init__(self):
 
         self.nr_brillouin_peaks = 1
+        self.spectra = {}
 
         self.results = {
             # Fitted values
@@ -97,3 +98,12 @@ class EvaluationModel(Serializer):
 
         self.results['rayleigh_peak_fwhm_f'] = np.empty(shape_rayleigh)
         self.results['rayleigh_peak_fwhm_f'][:] = np.nan
+
+    def set_spectra(self, image_key, spectra):
+        self.spectra[image_key] = spectra
+
+    def get_spectra(self, image_key):
+        spectra = self.spectra.get(image_key)
+        if spectra:
+            return spectra
+        return None

--- a/bmlab/models/extraction_model.py
+++ b/bmlab/models/extraction_model.py
@@ -15,7 +15,6 @@ class ExtractionModel(Serializer):
         self.circle_fits = {}
         self.circle_fits_index = []
         self.circle_fits_interpolation = None
-        self.extracted_values = {}
         self.extraction_angles = {}
         self.extraction_angles_index = None
         self.extraction_angles_interpolation = None
@@ -146,15 +145,6 @@ class ExtractionModel(Serializer):
             ]
             arc.append(np.array(points))
         return np.array(arc)
-
-    def set_extracted_values(self, calib_key, values):
-        self.extracted_values[calib_key] = values
-
-    def get_extracted_values(self, calib_key):
-        values = self.extracted_values.get(calib_key)
-        if values:
-            return values
-        return None
 
     def set_extraction_angles(self, calib_key, phis):
         self.extraction_angles[calib_key] = phis

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -7,7 +7,7 @@ import pathlib
 from bmlab import Session
 from bmlab.geometry import Circle, discretize_arc
 from bmlab.models import Orientation
-from bmlab.controllers import ExtractionController
+from bmlab.controllers import CalibrationController, ExtractionController
 
 DATA_DIR = pathlib.Path(__file__).parent / 'data'
 
@@ -52,10 +52,6 @@ def test_typical_use_case():
 
         assert em.get_points(calib_key) != points
         assert em.get_circle_fit(calib_key)
-        assert em.get_extracted_values(calib_key) is None
-
-        ec = ExtractionController()
-        ec.extract_calibration_spectrum(calib_key)
 
     # Calibration
     cm = session.calibration_model()
@@ -65,3 +61,8 @@ def test_typical_use_case():
         cm.add_brillouin_region(calib_key, (250, 304))
         cm.add_rayleigh_region(calib_key, (93, 127))
         cm.add_rayleigh_region(calib_key, (351, 387))
+
+        assert cm.get_spectra(calib_key) is None
+
+        cc = CalibrationController()
+        cc.extract_calibration_spectra(calib_key)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -12,7 +12,7 @@ from bmlab.session import Session
 from bmlab.geometry import Circle, discretize_arc
 from bmlab.models.calibration_model import FitSet, RayleighFit
 from bmlab.models.extraction_model import CircleFit
-from bmlab.controllers import ExtractionController
+from bmlab.controllers import CalibrationController
 
 
 @pytest.fixture()
@@ -45,6 +45,7 @@ def session_file(tmp_dir):
 
     cal = session.current_repetition().calibration
     em = session.extraction_model()
+    cm = session.calibration_model()
     for calib_key in session.get_calib_keys():
         points = [(100, 290), (145, 255), (290, 110)]
         time = cal.get_time(calib_key)
@@ -61,10 +62,10 @@ def session_file(tmp_dir):
         session.extraction_model().set_extraction_angles(calib_key, phis)
 
         assert em.get_circle_fit(calib_key)
-        assert em.get_extracted_values(calib_key) is None
+        assert cm.get_spectra(calib_key) is None
 
-        ec = ExtractionController()
-        ec.extract_calibration_spectrum(calib_key)
+        cc = CalibrationController()
+        cc.extract_calibration_spectra(calib_key)
 
     session.save()
 
@@ -90,6 +91,7 @@ def test_serialize_session(tmp_dir):
 
     cal = session.current_repetition().calibration
     em = session.extraction_model()
+    cm = session.calibration_model()
     for calib_key in session.get_calib_keys():
         points = [(100, 290), (145, 255), (290, 110)]
         time = cal.get_time(calib_key)
@@ -106,10 +108,10 @@ def test_serialize_session(tmp_dir):
         session.extraction_model().set_extraction_angles(calib_key, phis)
 
         assert em.get_circle_fit(calib_key)
-        assert em.get_extracted_values(calib_key) is None
+        assert cm.get_spectra(calib_key) is None
 
-        ec = ExtractionController()
-        ec.extract_calibration_spectrum(calib_key)
+        cc = CalibrationController()
+        cc.extract_calibration_spectra(calib_key)
 
     session.save()
 
@@ -125,9 +127,10 @@ def test_deserialize_session_file(session_file):
     session.set_file('Water.h5')
 
     em = session.extraction_model()
+    cm = session.calibration_model()
     assert em
     assert em.calib_times['2'] == 62.542
-    assert len(em.extracted_values['1']) > 0
+    assert len(cm.spectra['1']) > 0
     assert len(em.extraction_angles['2']) > 0
     assert em.circle_fits_interpolation is not None
 


### PR DESCRIPTION
This PR moves the extraction of the calibration spectra to the calibration controller and stores the calibration spectra in the calibration model.

Also, the payload spectra are now stored as well (in the evaluation model). This makes the session file a bit larger, but allows to retrieve the spectra faster later on again.