### PR TITLE
Add python 3.10 to build environment

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/deploy_pypi.yml
+++ b/.github/workflows/deploy_pypi.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
                       "pytest_mock",
                       "scikit-image>=0.19.0",
                       "scipy>=0.14.0",
-                      "shapely>=1.8.0"
+                      "shapely>=1.8.2"
                       ],
     # not to be confused with definitions in pyproject.toml [build-system]
     python_requires=">=3.7",


### PR DESCRIPTION
Currently blocked by https://github.com/shapely/shapely/issues/1215