### PR TITLE
Require python >= 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
                       "shapely>=1.8.0"
                       ],
     # not to be confused with definitions in pyproject.toml [build-system]
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     keywords=["Brillouin microscopy"],
     classifiers=['Operating System :: OS Independent',
                  'Programming Language :: Python :: 3',


### PR DESCRIPTION
Python 3.6 is EOL since 2021-12-23, see https://www.python.org/dev/peps/pep-0494/