### PR TITLE
Don't fail to set regions w/o calibration

### DIFF
--- a/bmlab/controllers.py
+++ b/bmlab/controllers.py
@@ -409,24 +409,24 @@ class PeakSelectionController(object):
         return
 
     def add_brillouin_region_frequency(self, region_frequency):
-        cm = self.session.calibration_model()
-        # We use the first measurement image here
-        time = self.session.get_payload_time('0')
-        region_pix = tuple(
-            cm.get_position_by_time(time, list(region_frequency)))
-
-        psm = self.session.peak_selection_model()
-        psm.add_brillouin_region(region_pix)
+        self.add_region_frequency(region_frequency, 'Brillouin')
 
     def add_rayleigh_region_frequency(self, region_frequency):
+        self.add_region_frequency(region_frequency, 'Rayleigh')
+
+    def add_region_frequency(self, region_frequency, peak_type):
         cm = self.session.calibration_model()
         # We use the first measurement image here
         time = self.session.get_payload_time('0')
-        region_pix = tuple(
-            cm.get_position_by_time(time, list(region_frequency)))
+        region_pix = cm.get_position_by_time(time, list(region_frequency))
+        if region_pix is None:
+            return
 
         psm = self.session.peak_selection_model()
-        psm.add_rayleigh_region(region_pix)
+        if peak_type == 'Brillouin':
+            psm.add_brillouin_region(tuple(region_pix))
+        if peak_type == 'Rayleigh':
+            psm.add_rayleigh_region(tuple(region_pix))
 
 
 class EvaluationController(ImageController):

--- a/bmlab/models/calibration_model.py
+++ b/bmlab/models/calibration_model.py
@@ -350,6 +350,8 @@ class CalibrationModel(Serializer):
 
         """
         spectrum = self.get_frequencies_by_time(time)
+        if spectrum is None:
+            return None
         f = interpolate.interp1d(spectrum, range(len(spectrum)))
         return f(frequencies)
 


### PR DESCRIPTION
Don't fail hard to set the evaluation regions by frequency if no calibration is available.

Closes https://github.com/BrillouinMicroscopy/BMicro/issues/221.