### PR TITLE
Invalidate results from old bmlab versions on file load

### DIFF
--- a/bmlab/controllers.py
+++ b/bmlab/controllers.py
@@ -340,7 +340,9 @@ class CalibrationController(ImageController):
         cm.set_vipa_params(calib_key, vipa_params)
         cm.set_frequencies(calib_key, time, frequencies)
 
-        calculate_derived_values()
+        evm = self.session.evaluation_model()
+        if evm is not None:
+            evm.invalidate_results()
 
     def clear_calibration(self, calib_key):
         cm = self.session.calibration_model()
@@ -352,7 +354,9 @@ class CalibrationController(ImageController):
         cm.clear_frequencies(calib_key)
         cm.clear_vipa_params(calib_key)
 
-        calculate_derived_values()
+        evm = self.session.evaluation_model()
+        if evm is not None:
+            evm.invalidate_results()
 
     def fit_rayleigh_regions(self, calib_key):
         cm = self.session.calibration_model()

--- a/bmlab/models/evaluation_model.py
+++ b/bmlab/models/evaluation_model.py
@@ -79,6 +79,10 @@ class EvaluationModel(Serializer):
             if key in self.results:
                 del self.results[key]
 
+    def invalidate_results(self):
+        for key in self.parameters:
+            self.results[key][:] = np.nan
+
     @staticmethod
     def get_default_parameters():
         return OrderedDict({

--- a/bmlab/session.py
+++ b/bmlab/session.py
@@ -433,6 +433,9 @@ class Session(Serializer):
             # @since 0.6.0
             psm = session.peak_selection_model()
             cm = session.calibration_model()
+            evm = session.evaluation_model()
+            if not hasattr(psm, 'brillouin_regions_f'):
+                evm.invalidate_results()
             # We use the first measurement image here
             time = session.get_payload_time('0')
 


### PR DESCRIPTION
With bmlab 0.6.0 the way we evaluate data changes significantly, so we invalidate results from former bmlab versions.

Furthermore, due to how we evaluate now, changes to the calibration automatically invalidate the evaluated data as well.