### PR TITLE
Drop python 3.7

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/deploy_pypi.yml
+++ b/.github/workflows/deploy_pypi.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
                       "shapely>=1.8.2"
                       ],
     # not to be confused with definitions in pyproject.toml [build-system]
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     keywords=["Brillouin microscopy"],
     classifiers=['Operating System :: OS Independent',
                  'Programming Language :: Python :: 3',


### PR DESCRIPTION
Python 3.7. will be EOL on 2023-06-27. However, e.g. scipy@latest already requires python >=3.8 so we will drop the support for python 3.7. already.