### PR TITLE
chore: drop py 3.8, add 3.11 and 3.12

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/deploy_pypi.yml
+++ b/.github/workflows/deploy_pypi.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
                       "shapely>=1.8.2"
                       ],
     # not to be confused with definitions in pyproject.toml [build-system]
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     keywords=["Brillouin microscopy"],
     classifiers=['Operating System :: OS Independent',
                  'Programming Language :: Python :: 3',


### PR DESCRIPTION
Python 3.8 will be EOL soon, and Python 3.12 came out a while ago already. This adjusts the supported Python versions.