### PR TITLE
chore(file): sort image keys numerically by default

### DIFF
--- a/bmlab/file.py
+++ b/bmlab/file.py
@@ -258,7 +258,8 @@ class MeasurementData(object):
         if self.data:
             keys = list(self.data.keys())
             if not sort_by_time:
-                return keys
+                keys_int = [int(key) for key in keys]
+                return [i for _, i in sorted(zip(keys_int, keys))]
 
             dates = []
             for key in keys:


### PR DESCRIPTION
The image keys are strings and have string order by default, so ['1', '10', '100', '101', .... '2'] which leads to a somehow weird order when evaluating. This adjusts it to always use integer order.