### PR TITLE
fix(fits): ignore NaN values when fitting

### DIFF
--- a/bmlab/fits.py
+++ b/bmlab/fits.py
@@ -382,6 +382,10 @@ def fit_lorentz_region(region, xdata, ydata, nr_peaks=1,
         idx_r = np.nanargmin(np.abs(xdata - region[1]))
         x = xdata[idx_l:idx_r]
         y = ydata[idx_l:idx_r]
+        # Mask all NaN values
+        mask = ~(np.isnan(x) | np.isnan(y))
+        x = x[mask]
+        y = y[mask]
         if nr_peaks == 1:
             w0s, fwhms, intensities, offset = fit_lorentz(
                 x, y)


### PR DESCRIPTION
The Lorentz fit does not work if the spectrum contains NaN values. This can happen at the beginning or end of the spectrum and might lead e.g. to only one Rayleigh peak to be fitted.

Masking the NaN values fixes this.